### PR TITLE
Add status update to end of upgrade action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -71,8 +71,8 @@ class LicenseManagerCliCharm(CharmBase):
             self._license_manager_cli_ops.upgrade(version)
             event.set_results({"upgrade": "success"})
         except Exception:
-            self.unit.status = BlockedStatus("Error upgrading cluster-agent")
-            event.fail(message="Error upgrading cluster-agent")
+            self.unit.status = BlockedStatus("Error upgrading license-manager-cli")
+            event.fail(message="Error upgrading license-manager-cli")
             event.defer()
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,13 @@ class LicenseManagerCliCharm(CharmBase):
     def _on_upgrade_action(self, event):
         """Upgrade the license-manager-cli package."""
         version = event.params["version"]
-        self._license_manager_cli_ops.upgrade(version)
+        try:
+            self._license_manager_cli_ops.upgrade(version)
+            event.set_results({"upgrade": "success"})
+        except Exception:
+            self.unit.status = BlockedStatus("Error upgrading cluster-agent")
+            event.fail(message="Error upgrading cluster-agent")
+            event.defer()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Each of the juju charms should update their statuses at the end of the upgrade action. Otherwise, we have to wait for 5 minutes for juju to run another check.

https://app.clickup.com/t/18022949/ARMADA-852