### PR TITLE
ASP-2378: Add an action to show the version of license-manager-cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,5 +6,6 @@ This file keeps track of all notable changes to the License Manager CLI charm.
 
 Unreleased
 ----------
-Create charm to install license-manager-cli
-Change version of Python to 3.8
+- Add an action to show the version of license-manager-cli.
+- Change version of Python to 3.8
+- Create charm to install license-manager-cli

--- a/actions.yaml
+++ b/actions.yaml
@@ -7,3 +7,7 @@ upgrade:
       description: Version of license-manager-cli to upgrade to.
   required:
     - version
+
+show-version:
+  description: >
+    Display the version and information about license-manager-cli.

--- a/src/charm.py
+++ b/src/charm.py
@@ -31,6 +31,7 @@ class LicenseManagerCliCharm(CharmBase):
 
         event_handler_bindings = {
             self.on.install: self._on_install,
+            self.on.upgrade_charm: self._on_upgrade,
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,6 +34,7 @@ class LicenseManagerCliCharm(CharmBase):
             self.on.config_changed: self._on_config_changed,
             self.on.remove: self._on_remove,
             self.on.upgrade_action: self._on_upgrade_action,
+            self.on.show_version_action: self._on_show_version_action,
         }
         for event, handler in event_handler_bindings.items():
             self.framework.observe(event, handler)
@@ -59,6 +60,11 @@ class LicenseManagerCliCharm(CharmBase):
     def _on_upgrade(self, event):
         """Perform upgrade operations."""
         self.unit.set_workload_version(Path("version").read_text().strip())
+
+    def _on_show_version_action(self, event):
+        """Show the info and version of license-manager-cli."""
+        info = self._license_manager_cli_ops.get_version_info()
+        event.set_results({"license-manager-cli": info})
 
     def _on_config_changed(self, event):
         """Configure license-manager-cli with charm config."""

--- a/src/license_manager_cli_ops.py
+++ b/src/license_manager_cli_ops.py
@@ -132,6 +132,20 @@ class LicenseManagerCliOps:
         else:
             logger.debug("license-manager-cli upgraded")
 
+    def get_version_info(self):
+        """Show version and info about license-manager-cli."""
+        cmd = [
+            self._VENV_PYTHON,
+            "-m",
+            "pip",
+            "show",
+            self._PACKAGE_NAME
+        ]
+
+        out = subprocess.check_output(cmd, env={}).decode().strip()
+
+        return out
+
     def configure_etc_default(self):
         """Create the default env file with the charm's configurations."""
         charm_config = self._charm.model.config


### PR DESCRIPTION
**What**

Add an action named `show-version` to display all information returned by `pip show license-manger-cli`, which includes the version of the package.

Usage: `juju run-action license-manager-cli/leader show-version --wait`

**Why**

With that, we can easily check the version and relate information about the software without the need to log in to the node.