### PR TITLE
feat: ASP-3288 Use Python 3.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 
 * Drop Python 3.6 support
 * Drop CentOS 8 support
+* Installed Python 3.12 to run the CLI
 
 1.0.2 - 2023-08-08
 ------------------

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,7 +13,6 @@ bases:
       - name: centos
         channel: "7"
         architectures: [amd64]
-
 parts:
   charm:
     charm-python-packages: [setuptools]

--- a/dispatch
+++ b/dispatch
@@ -8,15 +8,17 @@ set -e
 # Source the os-release information into the env
 . /etc/os-release
 
+PYTHON_BIN=/opt/python/python3.12/bin/python3.12
+
 if ! [[ -f '.installed' ]]
 then
-    if [[ ! -e /usr/local/bin/python3.8 ]]
+    if [[ ! -e $PYTHON_BIN ]]
     then
         if [[ $ID == 'centos' || $ID == 'rocky' ]]
         then
             # Install dependencies to build custom python
             yum -y install epel-release
-            yum -y install wget gcc make tar bzip2-devel zlib-devel xz-devel openssl-devel libffi-devel sqlite-devel ncurses-devel
+            yum -y install wget gcc make tar bzip2-devel zlib-devel xz-devel openssl-devel libffi-devel sqlite-devel ncurses-devel openssl11-libs openssl11-devel tk-devel libreadline-devel libgdbm-devel
 
             # Install yaml deps
             yum -y install libyaml-devel            
@@ -28,24 +30,18 @@ then
             apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
         fi
 
-        export PYTHON_VERSION=3.8.16
+        export PYTHON_VERSION=3.12.1
         wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz -P /tmp
         tar xvf /tmp/Python-${PYTHON_VERSION}.tar.xz -C /tmp
         cd /tmp/Python-${PYTHON_VERSION}
-        ./configure --enable-optimizations
+        export CFLAGS="$CFLAGS $(pkg-config --cflags openssl11)"
+		export LDFLAGS="$LDFLAGS $(pkg-config --libs openssl11)"
+        ./configure --prefix=/opt/python/python3.12 --enable-optimizations
         make -C /tmp/Python-${PYTHON_VERSION} -j $(nproc) altinstall
         cd $OLDPWD
         rm -rf /tmp/Python*
     fi
 	touch .installed
-fi
-
-# set the correct python bin path
-if [[ $ID == "centos" || $ID == "rocky" ]]
-then
-	PYTHON_BIN="/usr/bin/env python3.8"
-else
-	PYTHON_BIN="/usr/bin/env python3"
 fi
 
 JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv $PYTHON_BIN ./src/charm.py

--- a/src/license_manager_cli_ops.py
+++ b/src/license_manager_cli_ops.py
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 class LicenseManagerCliOps:
     """Track and perform license-manager-cli ops."""
 
-    _PYTHON_BIN = Path("/usr/local/bin/python3.8")
+    _PYTHON_BIN = Path("/opt/python/python3.12/bin/python3.12")
     _PACKAGE_NAME = "license-manager-cli"
     _LOG_DIR = Path("/var/log/license-manager-cli")
     _ETC_DEFAULT = Path("/etc/default/lm-cli")


### PR DESCRIPTION
- Remove support for CentOS 8
- Install and use Python 3.12 to run the agent.